### PR TITLE
Enable Serialization/Deserialization round-trip for Domain objects

### DIFF
--- a/src/namecheap/models.py
+++ b/src/namecheap/models.py
@@ -239,15 +239,15 @@ class Domain(XMLModel):
     @field_validator("created", "expires", mode="before")
     @classmethod
     def parse_datetime(cls, v: Any) -> datetime:
-        """Parse datetime strings."""
+        """Parse datetime from Namecheap API or Pydantic serialization."""
         if isinstance(v, datetime):
             return v
         if isinstance(v, str):
-            # Namecheap uses MM/DD/YYYY format
-            if (v.find('T') == 01):
+            # Namecheap API format (MM/DD/YYYY)
+            if '/' in v:
                 return datetime.strptime(v, "%m/%d/%Y")
-            else:
-                return datetime.fromisoformat(v)
+            # Pydantic serialization format (ISO 8601)
+            return datetime.fromisoformat(v)
         raise ValueError(f"Cannot parse datetime from {v}")
 
 

--- a/src/namecheap/models.py
+++ b/src/namecheap/models.py
@@ -244,7 +244,10 @@ class Domain(XMLModel):
             return v
         if isinstance(v, str):
             # Namecheap uses MM/DD/YYYY format
-            return datetime.strptime(v, "%m/%d/%Y")
+            if (v.find('T') == 01):
+                return datetime.strptime(v, "%m/%d/%Y")
+            else:
+                return datetime.fromisoformat(v)
         raise ValueError(f"Cannot parse datetime from {v}")
 
 


### PR DESCRIPTION
The custom validator on the 'created' and 'expires' fields on the Domain object allowed for either a datetime object directly, or Namecheap's 'MM/DD/YYYY' string format. But if you serialize the object (ie, model_dump_json()) and then try to deserialize it using the Domain model, it would fail because those fields would have strings of the format 'YYYY-MM-DDThh-mm-ss' which wouldn't validate.

This adds a quick if/else to see if there is a 'T' in the datetimestamp string, if so it uses datetime.fromisoformat(v), rather than the datetime.strptime(v, "%m/%d/%Y').

This change allows a Domain object to be serialized to JSON, and reserialized back into a Domain object.