### PR TITLE
feat: add nameserver management

### DIFF
--- a/README.md
+++ b/README.md
@@ -375,3 +375,7 @@ MIT License - see [LICENSE](LICENSE) file for details.
 ## 🤝 Contributing
 
 Contributions are welcome! Please feel free to submit a Pull Request. See the [Development Guide](docs/dev/README.md) for setup instructions and guidelines.
+
+### Contributors
+
+- [@cosmin](https://github.com/cosmin) — Nameserver management

--- a/README.md
+++ b/README.md
@@ -260,6 +260,24 @@ nc.dns.set("example.com",
 
 **Note on TTL:** The default TTL is **1799 seconds**, which displays as **"Automatic"** in the Namecheap web interface. This is an undocumented Namecheap API behavior. You can specify custom TTL values (60-86400 seconds) in any DNS method.
 
+### Nameserver Management
+
+```python
+# Check current nameservers
+ns = nc.dns.get_nameservers("example.com")
+print(ns.nameservers)  # ['dns1.registrar-servers.com', 'dns2.registrar-servers.com']
+print(ns.is_default)   # True
+
+# Switch to custom nameservers (e.g., Cloudflare, Route 53)
+nc.dns.set_custom_nameservers("example.com", [
+    "ns1.cloudflare.com",
+    "ns2.cloudflare.com",
+])
+
+# Reset back to Namecheap BasicDNS
+nc.dns.set_default_nameservers("example.com")
+```
+
 ### Domain Management
 
 ```python
@@ -339,7 +357,7 @@ The following Namecheap API features are planned for future releases:
 
 - **SSL API** - Certificate management
 - **Domain Transfer API** - Transfer domains between registrars
-- **Domain NS API** - Custom nameserver management
+- **Domain NS API** - Glue record management (child nameservers)
 - **Users API** - Account management and balance checking
 - **Whois API** - WHOIS information lookups
 - **Email Forwarding** - Email forwarding configuration

--- a/pending.md
+++ b/pending.md
@@ -60,6 +60,9 @@ Based on the previous Namecheap Python SDK implementation, here's what's still p
 - ✅ `set()` - Set DNS records (with builder pattern!)
 - ✅ `add()` - Add single record
 - ✅ `delete()` - Delete records
+- ✅ `set_custom_nameservers()` - Switch to custom nameservers (e.g., Route 53)
+- ✅ `set_default_nameservers()` - Reset to Namecheap BasicDNS
+- ✅ `get_nameserver_info()` - Get current nameserver configuration
 
 ### Enhanced Features
 - ✅ Smart IP detection and validation

--- a/pending.md
+++ b/pending.md
@@ -32,11 +32,11 @@ Based on the previous Namecheap Python SDK implementation, here's what's still p
 - `updateStatus()` - Approve/reject transfer
 - `getList()` - List pending transfers
 
-### 4. **Domains NS API** (`namecheap.domains.ns.*`)
-- `create()` - Create nameserver
-- `delete()` - Delete nameserver
-- `getInfo()` - Get nameserver details
-- `update()` - Update nameserver IP
+### 4. **Domains NS API** (`namecheap.domains.ns.*`) — Glue Records
+- `create()` - Register a child nameserver (e.g., ns1.yourdomain.com → 1.2.3.4)
+- `delete()` - Delete a child nameserver
+- `getInfo()` - Get child nameserver details
+- `update()` - Update child nameserver IP
 
 ### 5. **Whois API** (`namecheap.whois.*`)
 - `getWhoisInfo()` - Get WHOIS information
@@ -62,7 +62,7 @@ Based on the previous Namecheap Python SDK implementation, here's what's still p
 - ✅ `delete()` - Delete records
 - ✅ `set_custom_nameservers()` - Switch to custom nameservers (e.g., Route 53)
 - ✅ `set_default_nameservers()` - Reset to Namecheap BasicDNS
-- ✅ `get_nameserver_info()` - Get current nameserver configuration
+- ✅ `get_nameservers()` - Get current nameserver configuration
 
 ### Enhanced Features
 - ✅ Smart IP detection and validation

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "namecheap-python"
-version = "1.0.6"
+version = "1.1.0"
 description = "A friendly Python SDK for Namecheap API"
 authors = [{name = "Adrian Galilea Delgado", email = "adriangalilea@gmail.com"}]
 readme = "README.md"

--- a/src/namecheap/__init__.py
+++ b/src/namecheap/__init__.py
@@ -12,9 +12,9 @@ from __future__ import annotations
 
 from .client import Namecheap
 from .errors import ConfigurationError, NamecheapError, ValidationError
-from .models import Contact, DNSRecord, Domain, DomainCheck
+from .models import Contact, DNSRecord, Domain, DomainCheck, Nameservers
 
-__version__ = "1.0.5"
+__version__ = "1.1.0"
 __all__ = [
     "ConfigurationError",
     "Contact",
@@ -23,5 +23,6 @@ __all__ = [
     "DomainCheck",
     "Namecheap",
     "NamecheapError",
+    "Nameservers",
     "ValidationError",
 ]

--- a/src/namecheap/_api/dns.py
+++ b/src/namecheap/_api/dns.py
@@ -406,6 +406,8 @@ class DnsAPI(BaseAPI):
         """
         if not nameservers:
             raise ValueError("At least one nameserver is required")
+        if len(nameservers) > 5:
+            raise ValueError("Maximum of 5 nameservers allowed")
 
         # Parse domain
         ext = tldextract.extract(domain)

--- a/src/namecheap/models.py
+++ b/src/namecheap/models.py
@@ -251,6 +251,13 @@ class Domain(XMLModel):
         raise ValueError(f"Cannot parse datetime from {v}")
 
 
+class Nameservers(BaseModel):
+    """Current nameserver configuration for a domain."""
+
+    is_default: bool = Field(description="True when using Namecheap's own DNS")
+    nameservers: list[str] = Field(description="Nameserver hostnames")
+
+
 class Contact(BaseModel):
     """Contact information for domain registration."""
 

--- a/src/namecheap_cli/__main__.py
+++ b/src/namecheap_cli/__main__.py
@@ -750,10 +750,6 @@ def dns_set_nameservers(
     """
     nc = config.init_client()
 
-    if not nameservers:
-        console.print("[red]❌ At least one nameserver is required[/red]")
-        sys.exit(1)
-
     try:
         if not yes and not config.quiet:
             console.print(f"\n[yellow]Setting custom nameservers for {domain}:[/yellow]")

--- a/uv.lock
+++ b/uv.lock
@@ -200,7 +200,7 @@ wheels = [
 
 [[package]]
 name = "namecheap-python"
-version = "1.0.5"
+version = "1.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
Add support for setting and querying custom nameservers for domains.

Library API:
- nc.dns.set_custom_nameservers(domain, nameservers) - switch to custom NS
- nc.dns.set_default_nameservers(domain) - reset to Namecheap BasicDNS
- nc.dns.get_nameserver_info(domain) - get current NS configuration

CLI commands:
- namecheap-cli dns set-nameservers <domain> <ns1> <ns2> ...
- namecheap-cli dns reset-nameservers <domain>
- namecheap-cli dns nameservers <domain>