### PR TITLE
Fix AttributeError in domains.list() for accounts with no domains

### DIFF
--- a/src/namecheap/_api/base.py
+++ b/src/namecheap/_api/base.py
@@ -99,6 +99,18 @@ def normalize_xml_response(data: dict[str, Any]) -> dict[str, Any]:
     return normalized
 
 
+def navigate_path(result: Any, path: str) -> Any:
+    """Walk a dot-separated path into a parsed XML response.
+
+    A self-closing element (e.g. ``<DomainGetListResult />`` returned for an
+    account with no domains) is parsed as None, so navigating through it must
+    not raise; treat a None segment as an empty result.
+    """
+    for key in path.split("."):
+        result = (result or {}).get(key, {})
+    return result
+
+
 class BaseAPI:
     """Base class for API endpoints."""
 
@@ -175,8 +187,7 @@ class BaseAPI:
 
         # Navigate to specific path if provided
         if path:
-            for key in path.split("."):
-                result = result.get(key, {})
+            result = navigate_path(result, path)
 
         # Return empty list if no results
         if not result:

--- a/src/namecheap/_api/base_check.py
+++ b/src/namecheap/_api/base_check.py
@@ -1,0 +1,27 @@
+"""Boundary checks for namecheap._api.base. Run: uv run python -m namecheap._api.base_check"""
+
+from namecheap._api.base import navigate_path
+
+
+def check_navigate_path_reaches_value() -> None:
+    data = {"DomainGetListResult": {"Domain": [{"@Name": "example.com"}]}}
+    assert navigate_path(data, "DomainGetListResult.Domain") == [
+        {"@Name": "example.com"}
+    ]
+
+
+def check_navigate_path_missing_key_returns_empty() -> None:
+    assert navigate_path({}, "DomainGetListResult.Domain") == {}
+
+
+def check_navigate_path_none_segment_returns_empty() -> None:
+    # Empty account: <DomainGetListResult /> is parsed as None by xmltodict.
+    data = {"DomainGetListResult": None, "Paging": {"TotalItems": "0"}}
+    assert navigate_path(data, "DomainGetListResult.Domain") == {}
+
+
+if __name__ == "__main__":
+    check_navigate_path_reaches_value()
+    check_navigate_path_missing_key_returns_empty()
+    check_navigate_path_none_segment_returns_empty()
+    print("ok: namecheap._api.base")


### PR DESCRIPTION
Fixes #10.

`domains.list()` crashes on any account with zero domains because Namecheap returns a self-closing `<DomainGetListResult />`, which xmltodict parses as `None`. The path walk in `base.py` then called `.get()` on that `None`. Guarding each segment with `(result or {})` lets it fall through to the existing empty-result branch and return `[]`.

I pulled the walk into a small `navigate_path` helper and added a `base_check.py` boundary check alongside it, covering the empty-account case plus the normal and missing-key paths.